### PR TITLE
added catch for song already on playlist

### DIFF
--- a/APIs/SongAPI.cs
+++ b/APIs/SongAPI.cs
@@ -84,6 +84,10 @@ namespace BE_MusicStreaming.APIs
                                   .SingleOrDefault(s => s.Id == songToAdd.SongId);
                     if (song != null)
                     {
+                        if (playlist.Songs.Contains(song))
+                        {
+                            return Results.BadRequest("song already on playlist");
+                        }
                         playlist.Songs.Add(song);
                         db.SaveChanges();
                         return Results.Ok("song added to playlist");


### PR DESCRIPTION
## Description
I added an if statement to check for whether song in payload was already on the playlist. If so, it returns a response that lets you know it is already there and thus can't be added again.

## Related Issue
#10 

## Motivation and Context
prevents 200 response of "song added" when in fact nothing is changing in the database.

## How Can This Be Tested?
swagger

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
